### PR TITLE
Command to open backstop results

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ instead just open the generated HTML-Report with your browser, e.g.:
 open tests/backstop/backstop_data/_mytestproject_/html_report/index.html 
 ```
 
+A ddev `host` command exists to open the latest report in your default browser: `ddev backstop-results`
+
 ## Changes to the original docker image
 
 The backstopjs docker image is extended with some functions using a custom docker build, see [Dockerfile](backstopBuild/Dockerfile)

--- a/commands/host/backstop-results
+++ b/commands/host/backstop-results
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+## Description: Launch a browser with latest backstop results
+## Usage: backstop-results
+## Example: "ddev backstop-results"
+
+case $OSTYPE in
+  linux-gnu)
+    xdg-open tests/backstop/backstop_data/html_report/index.html
+    ;;
+  "darwin"*)
+    open tests/backstop/backstop_data/html_report/index.html
+    ;;
+  "win*"* | "msys"*)
+    start tests/backstop/backstop_data/html_report/index.html
+    ;;
+esac

--- a/install.yaml
+++ b/install.yaml
@@ -14,6 +14,7 @@ project_files:
 - docker-compose.backstop.yaml
 - backstopBuild/
 - commands/backstop/backstop
+- commands/host/backstop-results
 
 post_install_actions:
  - echo "Install finished. Please restart ddev with 'ddev restart'"


### PR DESCRIPTION
Thanks for this repo, I've banged my head against the wall for a long time and couldn't make it work.

Small addition, a `ddev backstop-results` command to open the latest diff.