### PR TITLE
Support for webkit/firefox with Playwright

### DIFF
--- a/backstopBuild/Dockerfile
+++ b/backstopBuild/Dockerfile
@@ -17,3 +17,6 @@ RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (userad
 RUN apt update && apt install -y sudo; apt clean -qq && rm -rf /var/lib/apt/lists/*; echo "ALL ALL=NOPASSWD: ALL" > /etc/sudoers.d/ddev-backstop && chmod 440 /etc/sudoers.d/ddev-backstop
 
 RUN npm install -g minimist
+
+# Install playwright browsers
+RUN npx playwright install-deps && npm cache clean --force; apt clean -qq && rm -rf /var/lib/apt/lists/*

--- a/backstopBuild/Dockerfile
+++ b/backstopBuild/Dockerfile
@@ -12,7 +12,8 @@ ARG uid
 ARG gid
 RUN userdel -r node
 RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (useradd  -l -m -s "/bin/bash" --gid "$username" --comment '' --uid $uid "$username" || useradd  -l -m -s "/bin/bash" --gid "$username" --comment '' "$username" || useradd  -l -m -s "/bin/bash" --gid "$gid" --comment '' "$username" || useradd -l -m -s "/bin/bash" --comment '' $username )
-RUN echo "$username     ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
+# Add sudo and sudoers in manner similar to other ddev containers
+RUN apt update && apt install -y sudo; apt clean -qq && rm -rf /var/lib/apt/lists/*; echo "ALL ALL=NOPASSWD: ALL" > /etc/sudoers.d/ddev-backstop && chmod 440 /etc/sudoers.d/ddev-backstop
 
 RUN npm install -g minimist

--- a/backstopBuild/Dockerfile
+++ b/backstopBuild/Dockerfile
@@ -16,7 +16,7 @@ RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (userad
 # Add sudo and sudoers in manner similar to other ddev containers
 RUN apt update && apt install -y sudo; apt clean -qq && rm -rf /var/lib/apt/lists/*; echo "ALL ALL=NOPASSWD: ALL" > /etc/sudoers.d/ddev-backstop && chmod 440 /etc/sudoers.d/ddev-backstop
 
-RUN npm install -g minimist
+RUN npm install -g minimist && npm cache clean --force
 
 # Install playwright browsers
 RUN npx playwright install-deps && npm cache clean --force; apt clean -qq && rm -rf /var/lib/apt/lists/*

--- a/docker-compose.backstop.yaml
+++ b/docker-compose.backstop.yaml
@@ -11,10 +11,11 @@ services:
     build:
       context: './backstopBuild'
       args:
-        BASE_IMAGE: backstopjs/backstopjs:6.1.3
+        BASE_IMAGE: backstopjs/backstopjs:6.2.2
         username: $USER
         uid: $DDEV_GID
         gid: $DDEV_UID
+    image: backstopjs/backstopjs:6.2.2-${DDEV_SITENAME}-built
     user:  '$DDEV_UID:$DDEV_GID'
     # Add init to reap Chrome processes, as noted at
     # https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#running-puppeteer-in-docker

--- a/docker-compose.backstop.yaml
+++ b/docker-compose.backstop.yaml
@@ -13,8 +13,8 @@ services:
       args:
         BASE_IMAGE: backstopjs/backstopjs:6.2.2
         username: $USER
-        uid: $DDEV_GID
-        gid: $DDEV_UID
+        uid: $DDEV_UID
+        gid: $DDEV_GID
     image: backstopjs/backstopjs:6.2.2-${DDEV_SITENAME}-built
     user:  '$DDEV_UID:$DDEV_GID'
     # Add init to reap Chrome processes, as noted at


### PR DESCRIPTION
Thank you for this add-on! My team uses it all the time!

We've wanted to use it for checking other browsers via Playwright (webkit/firefox), but found a few changes were needed to make it work without customizing each project.

Functional updates made:
- Upgraded to BackstopJS 6.2.2
- Fixed issues preventing sudo
- Installed Playwright browser dependencies