### PR TITLE
Allow results to be opened from any directory

### DIFF
--- a/commands/host/backstop-results
+++ b/commands/host/backstop-results
@@ -8,6 +8,7 @@
 
 case $OSTYPE in
   linux-gnu)
+    cd `git rev-parse --show-toplevel`
     xdg-open tests/backstop/backstop_data/html_report/index.html
     ;;
   "darwin"*)


### PR DESCRIPTION
Allows backstop-results command to open the results page without having to be on the root directory.

The same change might/should work for macOS, but I don't have the means to test it. I do not know about Windows too, if anyone uses this in Windows can they please help?