### PR TITLE
Bump backstopjs image

### DIFF
--- a/docker-compose.backstop.yaml
+++ b/docker-compose.backstop.yaml
@@ -11,11 +11,11 @@ services:
     build:
       context: './backstopBuild'
       args:
-        BASE_IMAGE: backstopjs/backstopjs:6.2.2
+        BASE_IMAGE: backstopjs/backstopjs:6.3.3
         username: $USER
         uid: $DDEV_UID
         gid: $DDEV_GID
-    image: backstopjs/backstopjs:6.2.2-${DDEV_SITENAME}-built
+    image: backstopjs/backstopjs:6.3.3-${DDEV_SITENAME}-built
     user:  '$DDEV_UID:$DDEV_GID'
     # Add init to reap Chrome processes, as noted at
     # https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#running-puppeteer-in-docker


### PR DESCRIPTION
This PR bumps the backstopjs image from `6.2.2` to `6.3.3`.

This is desirable to remove the deprecation warning displayed when generating references (and probably testing too):

```shell
Puppeteer old Headless deprecation warning:
In the near feature 'headless: true' wilt default to the new Headless mode
for Chrome instead of the old Headless irplementation. For more ...
```

![deprecation](https://github.com/mmunz/ddev-backstopjs/assets/7234392/38ffbd65-df0e-42a8-be01-dfdbe413a95a)
