### PR TITLE
bump ddev test action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ on:
         description: 'Debug with tmate set "debug_enabled"'
         required: false
         default: "false"
-        
+
 jobs:
   tests:
     strategy:
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: ddev/github-action-add-on-test@v0
+    - uses: ddev/github-action-add-on-test@v1
       with:
         ddev_version: ${{ matrix.ddev_version }}
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR bumps the DDEV test action to the latest version, `v1`.

This was my oversight in #9, which incorrectly used an older verion, `v0`. 

My apologizes for the noise.
