### PR TITLE
Use `ddev add-on` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ config and for links to a more advanced example config.
 Install this addon with
 
 ```shell
-ddev get mmunz/ddev-backstopjs
+ddev add-on get mmunz/ddev-backstopjs
 ```
 
 After that you need to restart the ddev project:
@@ -34,7 +34,7 @@ By default, the backstop tests are expected in $DDEV_APPDIR/tests/backstop.
 
 Provide your own backstop.js or backstop.json configs there.
 
-Hint: have a look at my example [backstopjs-config](https://github.com/mmunz/backstopjs-config) 
+Hint: have a look at my example [backstopjs-config](https://github.com/mmunz/backstopjs-config)
 
 Alternatively you can create a simple backstop.json config with:
 
@@ -73,7 +73,7 @@ ddev backstop-results
 Alternatively open the generated HTML-Report with your browser, e.g.:
 
 ```shell
-open tests/backstop/backstop_data/_mytestproject_/html_report/index.html 
+open tests/backstop/backstop_data/_mytestproject_/html_report/index.html
 ```
 
 ## Changes to the original docker image

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -21,8 +21,8 @@ teardown() {
 @test "install from directory" {
   set -eu -o pipefail
   cd ${TESTDIR}
-  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ${DIR}
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get ${DIR}
   ddev restart
 
   # backstop is installed and can show its version
@@ -37,8 +37,8 @@ teardown() {
 #@test "install from release" {
 #  set -eu -o pipefail
 #  cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-#  echo "# ddev get drud/ddev-addon-template with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-#  ddev get drud/ddev-addon-template
+#  echo "# ddev add-on get drud/ddev-addon-template with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+#  ddev add-on get drud/ddev-addon-template
 #  ddev restart >/dev/null
 #  # Do something useful here that verifies the add-on
 #  # ddev exec "curl -s elasticsearch:9200" | grep "${PROJNAME}-elasticsearch"


### PR DESCRIPTION
This PR updates the tests to use the `ddev add-on` command.

`ddev get` was deprecated in `v1.23.5`.