### PR TITLE
feat: prepare to official release, fixes #22

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Exclude files from releases/tarballs
+tests/ export-ignore
+.github/ export-ignore
+.gitattributes export-ignore

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@
 <!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->
 
 ```bash
-ddev add-on get https://github.com/mmunz/ddev-backstopjs/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
+ddev add-on get https://github.com/ddev/ddev-backstopjs/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
 ddev restart
 ```
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,12 @@
 name: tests
 on:
   pull_request:
+    paths-ignore:
+      - "**.md"
   push:
     branches: [ main, develop ]
+    paths-ignore:
+      - "**.md"
 
   schedule:
   - cron: '25 08 * * *'
@@ -10,13 +14,17 @@ on:
   workflow_dispatch:
     inputs:
       debug_enabled:
-        description: 'Debug with tmate set "debug_enabled"'
+        type: boolean
+        description: Debug with tmate
         required: false
-        default: "false"
+        default: false
 
-# Required permissions for keep-alive, used by ddev/github-action-add-on-test
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
-  actions: write
+  contents: read
 
 jobs:
   tests:
@@ -28,10 +36,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: ddev/github-action-add-on-test@v2
-      with:
-        ddev_version: ${{ matrix.ddev_version }}
-        token: ${{ secrets.GITHUB_TOKEN }}
-        debug_enabled: ${{ github.event.inputs.debug_enabled }}
-        addon_repository: ${{ env.GITHUB_REPOSITORY }}
-        addon_ref: ${{ env.GITHUB_REF }}
+      - uses: ddev/github-action-add-on-test@v2
+        with:
+          ddev_version: ${{ matrix.ddev_version }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          debug_enabled: ${{ github.event.inputs.debug_enabled }}
+          addon_repository: ${{ env.GITHUB_REPOSITORY }}
+          addon_ref: ${{ env.GITHUB_REF }}

--- a/README.md
+++ b/README.md
@@ -3,128 +3,104 @@
 [![last commit](https://img.shields.io/github/last-commit/ddev/ddev-backstopjs)](https://github.com/ddev/ddev-backstopjs/commits)
 [![release](https://img.shields.io/github/v/release/ddev/ddev-backstopjs)](https://github.com/ddev/ddev-backstopjs/releases/latest)
 
-## ddev-backstopjs
+## DDEV BackstopJS
 
-This is a ddev-addon for [backstop.js](https://github.com/garris/BackstopJS), a visual regression testing tool.
-Backstop is executed in a docker container based on the official [backstopjs docker image](https://hub.docker.com/r/backstopjs/backstopjs).
+## Overview
 
-This addon just provides the basics to run backstopjs. No backstopjs config is included. See below how to generate a
+[BackstopJS](https://github.com/garris/BackstopJS) is a visual regression testing tool.
+
+This add-on provides the basics to run BackstopJS into your [DDEV](https://ddev.com) project. No backstopjs config is included. See below how to generate a
 config and for links to a more advanced example config.
 
-## Getting started
+## Installation
 
-Install this addon with
-
-```shell
+```bash
 ddev add-on get ddev/ddev-backstopjs
-```
-
-After that you need to restart the ddev project:
-
-```shell
 ddev restart
 ```
 
-**Note: If you haven't downloaded the backstopjs base image before, then it will be downloaded when ddev is restarted.
-The backstopjs/backstopjs is about 2.6GB, so this may take some time.**
+After installation, make sure to commit the `.ddev` directory to version control.
 
+> [!NOTE]
+> If you haven't downloaded the backstopjs base image before, then it will be downloaded when DDEV is restarted.
+> The `backstopjs/backstopjs` is about 2.6 GB, so this may take some time.
 
-## Using backstopjs
+## Usage
 
 ### Configuration
 
-By default, the backstop tests are expected in $DDEV_APPDIR/tests/backstop.
+By default, the backstop tests are expected in `$DDEV_APPROOT/tests/backstop`.
 
-Provide your own backstop.js or backstop.json configs there.
+Provide your own `backstop.js` or `backstop.json` configs there.
 
-Hint: have a look at my example [backstopjs-config](https://github.com/mmunz/backstopjs-config)
+> [!TIP]
+> Have a look at this example for [backstopjs-config](https://github.com/mmunz/backstopjs-config),
 
-Alternatively you can create a simple backstop.json config with:
+Alternatively, create a simple `backstop.json` config with:
 
-```shell
+```bash
 ddev backstop init
 ```
 
 ### Run tests
 
-After the config was created it is time to run the tests:
+After you created the config, you can run the tests.
 
 Create reference screenshots:
 
-```shell
+```bash
 ddev backstop reference
 ```
 
 Create test images and compare to reference screenshots:
 
-```shell
+```bash
 ddev backstop test
 ```
 
-If your config file is not 'backstop.json' you need to use the --config argument, e.g. --config=backstop.js
+If your config file is not `backstop.json`, use the `--config` argument, for example `--config=backstop.js`.
 
 ### View test results
 
-The backstop commands 'backstop remote' and 'backstop openReport' do not work in this setup.
+The BackstopJS commands `backstop remote` and `backstop openReport` don't work in this setup.
 
-But there is a host command that will open the latest test report in your default browser:
+However, there is a host command that opens the latest test report in your default browser:
 
-```shell
+```bash
 ddev backstop-results
 ```
 
-Alternatively open the generated HTML-Report with your browser, e.g.:
+Alternatively, open the generated HTML report in your browser, for example:
 
-```shell
+```bash
 open tests/backstop/backstop_data/_mytestproject_/html_report/index.html
 ```
 
-## Changes to the original docker image
+## Changes to the original Docker image
 
-The backstopjs docker image is extended with some functions using a custom docker build, see [Dockerfile](backstopBuild/Dockerfile)
-and uses a custom [entrypoint](backstopBuild/entrypoint.sh).
+The BackstopJS Docker image is extended with additional functionality using a custom Docker build. See [Dockerfile](backstopBuild/Dockerfile) and the custom [entrypoint](backstopBuild/entrypoint.sh).
 
-In the Dockerfile the following is added/changed:
+In the `Dockerfile`, the following changes are made:
 
-- add the custom entrypoint.sh to the image
-- delete the default 'node' user with uid 1000 and add current ddev user
-- install the [minimist](https://www.npmjs.com/package/minimist) npm package globally. This is not needed by default
-  but very handy to parse command line args for more complex custom backstopjs configs.
+- Add the custom `entrypoint.sh` to the image
+- Delete the default `node` user with UID 1000 and add the current DDEV user
+- Install the [minimist](https://www.npmjs.com/package/minimist) npm package globally. This is not required by default but is useful for parsing command-line arguments in more complex BackstopJS configs.
 
 The entrypoint is responsible for:
 
-- add /etc/hosts entries for all hosts configured in the ddev web container automatically
-- add sleep command to keep the container running
+- Adding `/etc/hosts` entries for all hosts configured in the DDEV web container
+- Adding a `sleep` command to keep the container running
 
-## Advanced
+## Advanced Customization
 
-### How to add additional hostnames?
+### Change the BackstopJS tests directory
 
-If you want to test hosts not configured in the web container, you need to use external_links in the service containers.
-For that add a file `docker-compose.external_links.yaml` to your project which should look like this:
+By default, the `backstop` directory (which contains the BackstopJS config and related files) is expected in your project directory, next to the `.ddev` folder, at `tests/backstop`.
 
-```yaml
-services:
-  backstop:
-    external_links:
-      - "ddev-router:myproject.ddev.site"
-      - "ddev-router:myproject2.ddev.site"
-```
+To change this, edit the file [docker-compose.backstop.yaml](docker-compose.backstop.yaml) and update the path in the `volumes` section. Move your files to the new directory and restart DDEV.
 
-See: [ddev FAQ: Can different projects communicate with each other?](https://ddev.readthedocs.io/en/latest/users/usage/faq/#features-requirements)
-
-
-### Change backstop tests directory
-Per default the backstop directory containing backstop config etc. is expected in your project directory (besides the
-.ddev folder) in the directory *tests/backstop*.
-
-If you want to change that edit the file [docker-compose.backstop.yaml](docker-compose.backstop.yaml) and
-change the line in volumes to the path you want to use, move the files to the new directory and restart ddev.
-
-Make sure to remove the #ddev-generated line from the file to prevent ddev from making changes to it.
+Make sure to remove the `#ddev-generated` line from the file to prevent DDEV from modifying it.
 
 ## Credits
 
 **Contributed and maintained by [@mmunz](https://github.com/mmunz)**
-
-**Maintained by the [DDEV team](https://ddev.com/support-ddev/)**

--- a/commands/backstop/backstop
+++ b/commands/backstop/backstop
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #ddev-generated
 

--- a/commands/backstop/backstop
+++ b/commands/backstop/backstop
@@ -8,7 +8,7 @@
 ## ExecRaw: true
 
 if [ "$1" == "openReport" -o "$1" == "remote" ]; then
-  echo "This does not work for backstop in ddev. See ddev backstop-results command."
+  echo "This does not work for backstop in DDEV. See 'ddev backstop-results' command."
   exit 1
 fi
 

--- a/commands/host/backstop-results
+++ b/commands/host/backstop-results
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #ddev-generated
 
@@ -8,12 +8,12 @@
 
 case $OSTYPE in
   linux-gnu)
-    xdg-open ${DDEV_APPROOT}/tests/backstop/backstop_data/html_report/index.html
+    xdg-open "${DDEV_APPROOT}/tests/backstop/backstop_data/html_report/index.html"
     ;;
   "darwin"*)
-    open ${DDEV_APPROOT}/tests/backstop/backstop_data/html_report/index.html
+    open "${DDEV_APPROOT}/tests/backstop/backstop_data/html_report/index.html"
     ;;
   "win*"* | "msys"*)
-    start ${DDEV_APPROOT}/tests/backstop/backstop_data/html_report/index.html
+    start "${DDEV_APPROOT}/tests/backstop/backstop_data/html_report/index.html"
     ;;
 esac

--- a/docker-compose.backstop.yaml
+++ b/docker-compose.backstop.yaml
@@ -11,7 +11,7 @@ services:
       context: './backstopBuild'
       args:
         BASE_IMAGE: backstopjs/backstopjs:6.3.25
-        username: $USER
+        username: $DDEV_USER
         uid: $DDEV_UID
         gid: $DDEV_GID
     image: backstopjs/backstopjs:6.3.25-${DDEV_SITENAME}-built
@@ -25,11 +25,8 @@ services:
       - .:/mnt/ddev_config:ro
     shm_size: 1gb
     environment:
-      DDEV_HOSTNAME: $DDEV_HOSTNAME
+      - DDEV_HOSTNAME
     # These labels ensure this service is discoverable by ddev.
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: ${DDEV_APPROOT}
-    networks:
-      ddev_default: null
-      default: null

--- a/install.yaml
+++ b/install.yaml
@@ -1,27 +1,22 @@
 name: ddev-backstopjs
 
-pre_install_actions:
-  - test -d ${DDEV_APPROOT}/tests/backstop || mkdir -p ${DDEV_APPROOT}/tests/backstop
-  - test -f "${DDEV_APPROOT}/tests/backstop/.gitignore" || printf "## ddev-generated\n**/bitmaps_test\n**/html_report\ncore\n" > ${DDEV_APPROOT}/tests/backstop/.gitignore
-  - grep -q "## ddev-generated" ${DDEV_APPROOT}/tests/backstop/.gitignore && printf "## ddev-generated\n**/bitmaps_test\n**/html_report\ncore\n" > ${DDEV_APPROOT}/tests/backstop/.gitignore || true
-
-
-# list of files and directories listed that are copied into project .ddev directory
-# Each file should contain #ddev-generated so it can be replaced by a later `ddev get`
-# if it hasn't been modified by the user.
-# DDEV environment variables can be interpolated into these filenames
 project_files:
-- docker-compose.backstop.yaml
-- backstopBuild/
-- commands/backstop/backstop
-- commands/host/backstop-results
+  - docker-compose.backstop.yaml
+  - backstopBuild/
+  - commands/backstop/backstop
+  - commands/host/backstop-results
 
 post_install_actions:
- - echo "Install finished. Please restart ddev with 'ddev restart'"
- - echo "After that create your backstop config, e.g. run ddev backstop init."
+ - |
+   #ddev-description:Create the backstop test directory
+   test -d "${DDEV_APPROOT}/tests/backstop" || mkdir -p "${DDEV_APPROOT}/tests/backstop"
+   test -f "${DDEV_APPROOT}/tests/backstop/.gitignore" || printf "#ddev-generated\n**/bitmaps_test\n**/html_report\ncore\n" > "${DDEV_APPROOT}/tests/backstop/.gitignore"
+   grep -q "#ddev-generated" "${DDEV_APPROOT}/tests/backstop/.gitignore" && printf "#ddev-generated\n**/bitmaps_test\n**/html_report\ncore\n" > "${DDEV_APPROOT}/tests/backstop/.gitignore" || true
+ - |
+   echo "Install finished. Please restart ddev with 'ddev restart'"
+   echo "After that create your backstop config, e.g. 'ddev backstop init'"
 
-# Version constraint for DDEV that will be validated against the running DDEV executable
-# and prevent add-on from being installed if it doesn't validate.
-# See https://github.com/Masterminds/semver#checking-version-constraints for constraint rules.
-# Available with DDEV v1.23.4+, and works only for DDEV v1.23.4+ binaries
-ddev_version_constraint: '>= v1.24.3'
+ddev_version_constraint: '>= v1.24.10'
+
+removal_actions:
+  - rm -rf "${DDEV_APPROOT}/tests/backstop"

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -44,6 +44,15 @@ health_checks() {
   run ddev backstop version
   assert_success
   assert_output --partial 'Command "version" successfully executed'
+
+  # openReport and remote commands show an error message
+  run ddev backstop openReport
+  assert_failure
+  assert_output --partial 'This does not work for backstop in DDEV'
+
+  run ddev backstop remote
+  assert_failure
+  assert_output --partial 'This does not work for backstop in DDEV'
 }
 
 teardown() {
@@ -68,13 +77,6 @@ teardown() {
 
   # Check service works
   health_checks
-
-  # openReport and remote commands show an error message
-  set +o pipefail
-  run ddev backstop openReport
-  assert_output --partial 'This does not work for backstop in ddev'
-  run ddev backstop remote
-  assert_output --partial 'This does not work for backstop in ddev'
 }
 
 # bats test_tags=release

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -16,7 +16,7 @@ setup() {
   set -eu -o pipefail
 
   # Override this variable for your add-on:
-  export GITHUB_REPO=mmunz/ddev-backstopjs
+  export GITHUB_REPO=ddev/ddev-backstopjs
 
   TEST_BREW_PREFIX="$(brew --prefix 2>/dev/null || true)"
   export BATS_LIB_PATH="${BATS_LIB_PATH}:${TEST_BREW_PREFIX}/lib:/usr/lib/bats"
@@ -48,8 +48,14 @@ health_checks() {
 
 teardown() {
   set -eu -o pipefail
-  ddev delete -Oy ${PROJNAME} >/dev/null 2>&1
-  [ "${TESTDIR}" != "" ] && rm -rf ${TESTDIR}
+  ddev delete -Oy "${PROJNAME}" >/dev/null 2>&1
+  # Persist TESTDIR if running inside GitHub Actions. Useful for uploading test result artifacts
+  # See example at https://github.com/ddev/github-action-add-on-test#preserving-artifacts
+  if [ -n "${GITHUB_ENV:-}" ]; then
+    [ -e "${GITHUB_ENV:-}" ] && echo "TESTDIR=${HOME}/tmp/${PROJNAME}" >> "${GITHUB_ENV}"
+  else
+    [ "${TESTDIR}" != "" ] && rm -rf "${TESTDIR}"
+  fi
 }
 
 @test "install from directory" {


### PR DESCRIPTION
## The Issue

- Fixes #22

```bash
curl -fsSL https://ddev.com/s/addon-update-checker.sh | bash
```

## How This PR Solves The Issue

Updates version constraint to v1.24.10
Applies best practices from the `addon-update-checker.sh`

## Manual Testing Instructions

Review https://github.com/ddev/ddev-backstopjs/blob/20260316_stasadev_release/README.md

```bash
ddev add-on get https://github.com/ddev/ddev-backstopjs/tarball/refs/pull/33/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
